### PR TITLE
Configure GitHub actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+env:
+  FORCE_COLOR: 1
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Lint
+        run: pnpm lint

--- a/.gitlab/merge_request_templates/Default.md
+++ b/.gitlab/merge_request_templates/Default.md
@@ -1,9 +1,0 @@
-#### Description
-
-[//]: # "Please include a summary of the change. Imagine you're trying to explain the changes to a reviewer."
-
-#### Resources
-
-[//]: # 'Please add links to the functional spec, design spec, dive-in, etc.'
-
-- <link>


### PR DESCRIPTION
As we're migrating to github, I considered it the right time to move our react-migration-toolkit and open source it for everyone to see what we've accomplished.

This change reimplements [the gitlab CI lint job](https://gitlab.qonto.co/npm-packages/react-migration-toolkit/-/blob/main/.gitlab-ci.yml#L31) to a github action.