### PR TITLE
fix(types): allow data-test-* and aria-* props to be passed to the bridge

### DIFF
--- a/react-migration-toolkit/src/components/react-bridge.gts
+++ b/react-migration-toolkit/src/components/react-bridge.gts
@@ -7,8 +7,13 @@ import './react-bridge.css';
 import { element, type ElementFromTagName } from 'ember-element-helper';
 import type { ComponentType } from 'react';
 
+type ExtraProps = Partial<{
+  [dataTestAttrs: `data-test-${string}`]: string;
+  [ariaAttrs: `aria-${string}`]: string;
+}>;
+
 type PropsOf<T> = T extends ComponentType<infer P>
-  ? Omit<P, 'children'>
+  ? Omit<P, 'children'> & ExtraProps
   : never;
 
 interface ReactBridgeArgs<T extends keyof HTMLElementTagNameMap, R> {

--- a/test-app/app/react/example.tsx
+++ b/test-app/app/react/example.tsx
@@ -9,7 +9,6 @@ import { useTheme } from "./theme-context.tsx";
 interface ExampleProps {
   text?: string;
   children?: ReactNode;
-  [testAttr: `data-test-${string}`]: string;
 }
 
 export function Example({ text, children, ...props }: ExampleProps): ReactNode {


### PR DESCRIPTION
In JSX, TS won't complain if we try to pass `data-test-*` or `aria-*` props to a component, but the same thing is not true with `createElement`. This PR explicitly allows those props to be passed under the `@props` argument.