### PR TITLE
feat(Link): create onClick handler to transition

### DIFF
--- a/react-migration-toolkit/src/react/components/link.tsx
+++ b/react-migration-toolkit/src/react/components/link.tsx
@@ -6,9 +6,15 @@ import { setUrlFromRelativePath, urlFromRouteInfo } from '../utils/router.ts';
 
 interface LinkProps extends Omit<ComponentPropsWithoutRef<'a'>, 'href'> {
   href: string | UrlObject;
+  replace?: boolean;
 }
 
-export function Link({ href, children, ...props }: LinkProps): ReactNode {
+export function Link({
+  href,
+  children,
+  replace,
+  ...props
+}: LinkProps): ReactNode {
   const router = useEmberService('router');
 
   const url = useMemo(() => {
@@ -29,7 +35,11 @@ export function Link({ href, children, ...props }: LinkProps): ReactNode {
 
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
-    router.transitionTo(url);
+    if (replace) {
+      router.replaceWith(url);
+    } else {
+      router.transitionTo(url);
+    }
   };
 
   return (

--- a/react-migration-toolkit/src/react/components/link.tsx
+++ b/react-migration-toolkit/src/react/components/link.tsx
@@ -27,8 +27,13 @@ export function Link({ href, children, ...props }: LinkProps): ReactNode {
     return '';
   }, [href, router]);
 
+  const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.preventDefault();
+    router.transitionTo(url);
+  };
+
   return (
-    <a href={url} {...props}>
+    <a href={url} onClick={onClick} {...props}>
       {children}
     </a>
   );

--- a/test-app/app/react/example-routing.tsx
+++ b/test-app/app/react/example-routing.tsx
@@ -10,6 +10,10 @@ export function ExampleRouting() {
         Visit About page
       </Link>
 
+      <Link data-test-about-link-replace href="/about" replace>
+        Visit About page
+      </Link>
+
       <button
         data-test-about-button-push
         onClick={() => {

--- a/test-app/tests/acceptance/links-test.js
+++ b/test-app/tests/acceptance/links-test.js
@@ -14,6 +14,13 @@ module('Acceptance | links', function (hooks) {
     assert.dom().hasText('Welcome to the About page');
   });
 
+  test('should navigate to the about page with replace', async function (assert) {
+    await visit('/links');
+    await click('[data-test-about-link-replace]');
+
+    assert.dom().hasText('Welcome to the About page');
+  });
+
   module('when navigating with Polymorphic router', function (hooks) {
     hooks.beforeEach(async function () {
       await visit('/links');


### PR DESCRIPTION
#### Description

This MR goal is to fix this component to work in environments without `ember-href-to`.  We're adding a click handler, using `router.transitionTo` instead, to avoid full page reload.

#### Reproduction instructions

If you have this project test app installed, you can reach `/links` page and assert the navigation with the 

### Resources
- [Slack thread where we discussed this fix](https://qonto.slack.com/archives/C05F2DR6H4P/p1739798802927039)