### PR TITLE
refactor(Link): rename href by to

### DIFF
--- a/react-migration-toolkit/src/react/components/link.tsx
+++ b/react-migration-toolkit/src/react/components/link.tsx
@@ -5,20 +5,20 @@ import { parseUrl } from '../utils/url.ts';
 import { setUrlFromRelativePath, urlFromRouteInfo } from '../utils/router.ts';
 
 interface LinkProps extends Omit<ComponentPropsWithoutRef<'a'>, 'href'> {
-  href: string | UrlObject;
   replace?: boolean;
+  to: string | UrlObject;
 }
 
 export function Link({
-  href,
   children,
   replace,
+  to,
   ...props
 }: LinkProps): ReactNode {
   const router = useEmberService('router');
 
   const url = useMemo(() => {
-    const parsedUrl = parseUrl(href);
+    const parsedUrl = parseUrl(to);
     let routeInfo;
 
     if (parsedUrl.startsWith('/')) {
@@ -31,7 +31,7 @@ export function Link({
       return urlFromRouteInfo(router, routeInfo);
     }
     return '';
-  }, [href, router]);
+  }, [to, router]);
 
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();

--- a/test-app/app/react/example-routing.tsx
+++ b/test-app/app/react/example-routing.tsx
@@ -6,11 +6,11 @@ export function ExampleRouting() {
 
   return (
     <div>
-      <Link data-test-about-link href="/about">
+      <Link data-test-about-link to="/about">
         Visit About page
       </Link>
 
-      <Link data-test-about-link-replace href="/about" replace>
+      <Link data-test-about-link-replace to="/about" replace>
         Visit About page
       </Link>
 


### PR DESCRIPTION
### Description 

This MR goal is to rename `href` property from `Link` to `to`. `href` was set to match with Next.js implementation. As we're going to use React router instead, we need to match with their [API](https://api.reactrouter.com/v7/functions/react_router.Link.html).

### Reproduction instructions

We expect a green pipeline 🟢 