### PR TITLE
feat(NavLink): create component

### DIFF
--- a/react-migration-toolkit/src/react/components/index.ts
+++ b/react-migration-toolkit/src/react/components/index.ts
@@ -1,1 +1,2 @@
 export { Link } from './link';
+export { NavLink } from './nav-link';

--- a/react-migration-toolkit/src/react/components/link.tsx
+++ b/react-migration-toolkit/src/react/components/link.tsx
@@ -4,7 +4,7 @@ import type { UrlObject } from '../types/router.ts';
 import { parseUrl } from '../utils/url.ts';
 import { setUrlFromRelativePath, urlFromRouteInfo } from '../utils/router.ts';
 
-interface LinkProps extends Omit<ComponentPropsWithoutRef<'a'>, 'href'> {
+export interface LinkProps extends Omit<ComponentPropsWithoutRef<'a'>, 'href'> {
   replace?: boolean;
   to: string | UrlObject;
 }

--- a/react-migration-toolkit/src/react/components/nav-link.tsx
+++ b/react-migration-toolkit/src/react/components/nav-link.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { useEmberService } from '../hooks/use-ember-service.ts';
 import { Link, type LinkProps } from './link';
 
@@ -7,9 +7,12 @@ export type NavLinkRenderProps = {
 };
 
 export interface NavLinkProps
-  extends Omit<LinkProps, 'className' | 'children'> {
+  extends Omit<LinkProps, 'className' | 'children' | 'style'> {
   children?: ReactNode | ((props: NavLinkRenderProps) => ReactNode);
   className?: string | ((props: NavLinkRenderProps) => string | undefined);
+  style?:
+    | CSSProperties
+    | ((props: NavLinkRenderProps) => CSSProperties | undefined);
 }
 
 export function NavLink({
@@ -17,6 +20,7 @@ export function NavLink({
   children,
   className: classNameProp,
   to,
+  style: styleProp,
   ...props
 }: NavLinkProps): ReactNode {
   let className: string | undefined;
@@ -38,8 +42,17 @@ export function NavLink({
       .join(' ');
   }
 
+  const style =
+    typeof styleProp === 'function' ? styleProp(renderProps) : styleProp;
+
   return (
-    <Link aria-current={ariaCurrent} className={className} to={to} {...props}>
+    <Link
+      aria-current={ariaCurrent}
+      className={className}
+      style={style}
+      to={to}
+      {...props}
+    >
       {typeof children === 'function' ? children(renderProps) : children}
     </Link>
   );

--- a/react-migration-toolkit/src/react/components/nav-link.tsx
+++ b/react-migration-toolkit/src/react/components/nav-link.tsx
@@ -1,9 +1,41 @@
 import type { ReactNode } from 'react';
+import { useEmberService } from '../hooks/use-ember-service.ts';
 import { Link, type LinkProps } from './link';
 
-export function NavLink({ to, children, ...props }: LinkProps): ReactNode {
+export type NavLinkRenderProps = {
+  isActive: boolean;
+};
+
+export interface NavLinkProps extends Omit<LinkProps, 'className'> {
+  className?: string | ((props: NavLinkRenderProps) => string | undefined);
+}
+
+export function NavLink({
+  children,
+  className: classNameProp,
+  to,
+  ...props
+}: NavLinkProps): ReactNode {
+  let className: string | undefined;
+  const router = useEmberService('router');
+  const locationPathname = router.currentURL;
+
+  const isActive = locationPathname === to;
+
+  const renderProps = {
+    isActive,
+  };
+
+  if (typeof classNameProp === 'function') {
+    className = classNameProp(renderProps);
+  } else {
+    className = [classNameProp, isActive ? 'active' : null]
+      .filter(Boolean)
+      .join(' ');
+  }
+
   return (
-    <Link to={to} {...props}>
+    <Link className={className} to={to} {...props}>
       {children}
     </Link>
   );

--- a/react-migration-toolkit/src/react/components/nav-link.tsx
+++ b/react-migration-toolkit/src/react/components/nav-link.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { Link, type LinkProps } from './link';
+
+export function NavLink({ to, children, ...props }: LinkProps): ReactNode {
+  return (
+    <Link to={to} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/react-migration-toolkit/src/react/components/nav-link.tsx
+++ b/react-migration-toolkit/src/react/components/nav-link.tsx
@@ -11,6 +11,7 @@ export interface NavLinkProps extends Omit<LinkProps, 'className'> {
 }
 
 export function NavLink({
+  'aria-current': ariaCurrentProp = 'page',
   children,
   className: classNameProp,
   to,
@@ -21,6 +22,7 @@ export function NavLink({
   const locationPathname = router.currentURL;
 
   const isActive = locationPathname === to;
+  const ariaCurrent = isActive ? ariaCurrentProp : undefined;
 
   const renderProps = {
     isActive,
@@ -35,7 +37,7 @@ export function NavLink({
   }
 
   return (
-    <Link className={className} to={to} {...props}>
+    <Link aria-current={ariaCurrent} className={className} to={to} {...props}>
       {children}
     </Link>
   );

--- a/react-migration-toolkit/src/react/components/nav-link.tsx
+++ b/react-migration-toolkit/src/react/components/nav-link.tsx
@@ -6,7 +6,9 @@ export type NavLinkRenderProps = {
   isActive: boolean;
 };
 
-export interface NavLinkProps extends Omit<LinkProps, 'className'> {
+export interface NavLinkProps
+  extends Omit<LinkProps, 'className' | 'children'> {
+  children?: ReactNode | ((props: NavLinkRenderProps) => ReactNode);
   className?: string | ((props: NavLinkRenderProps) => string | undefined);
 }
 
@@ -38,7 +40,7 @@ export function NavLink({
 
   return (
     <Link aria-current={ariaCurrent} className={className} to={to} {...props}>
-      {children}
+      {typeof children === 'function' ? children(renderProps) : children}
     </Link>
   );
 }

--- a/test-app/tests/integration/components/nav-link-test.js
+++ b/test-app/tests/integration/components/nav-link-test.js
@@ -30,6 +30,7 @@ module('Integration | Component | NavLink', function (hooks) {
 
     assert.dom('[data-test-nav-link]').exists();
     assert.dom('[data-test-nav-link]').doesNotHaveClass('active');
+    assert.dom('[data-test-nav-link]').hasNoAttribute('aria-current');
   });
 
   module('when route is active', function (hooks) {
@@ -44,7 +45,7 @@ module('Integration | Component | NavLink', function (hooks) {
       );
     });
 
-    test('should have active class', async function (assert) {
+    test('should have active properties', async function (assert) {
       await render(hbs`
         <ReactBridge
           @reactComponent={{this.navLink}}
@@ -54,6 +55,7 @@ module('Integration | Component | NavLink', function (hooks) {
       `);
 
       assert.dom('[data-test-nav-link]').hasClass('active');
+      assert.dom('[data-test-nav-link]').hasAttribute('aria-current', 'page');
     });
 
     test('should concatenate active class', async function (assert) {
@@ -82,6 +84,18 @@ module('Integration | Component | NavLink', function (hooks) {
       `);
 
       assert.dom('[data-test-nav-link]').hasClass('custom-active');
+    });
+
+    test('should have custom aria-current', async function (assert) {
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.navLink}}
+          @props={{hash aria-current="custom" to="/active" data-test-nav-link=""}}
+          @providerOptions={{this.reactProviderOptions}}
+        />
+      `);
+
+      assert.dom('[data-test-nav-link]').hasAttribute('aria-current', 'custom');
     });
   });
 });

--- a/test-app/tests/integration/components/nav-link-test.js
+++ b/test-app/tests/integration/components/nav-link-test.js
@@ -29,5 +29,59 @@ module('Integration | Component | NavLink', function (hooks) {
     `);
 
     assert.dom('[data-test-nav-link]').exists();
+    assert.dom('[data-test-nav-link]').doesNotHaveClass('active');
+  });
+
+  module('when route is active', function (hooks) {
+    hooks.beforeEach(function () {
+      this.owner.register(
+        'service:router',
+        {
+          recognize: () => {},
+          currentURL: '/active',
+        },
+        { instantiate: false },
+      );
+    });
+
+    test('should have active class', async function (assert) {
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.navLink}}
+          @props={{hash to="/active" data-test-nav-link=""}}
+          @providerOptions={{this.reactProviderOptions}}
+        />
+      `);
+
+      assert.dom('[data-test-nav-link]').hasClass('active');
+    });
+
+    test('should concatenate active class', async function (assert) {
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.navLink}}
+          @props={{hash className="my-class" to="/active" data-test-nav-link=""}}
+          @providerOptions={{this.reactProviderOptions}}
+        />
+      `);
+
+      assert
+        .dom('[data-test-nav-link]')
+        .hasClass('active')
+        .hasClass('my-class');
+    });
+
+    test('should have custom active class', async function (assert) {
+      this.className = ({ isActive }) => (isActive ? 'custom-active' : '');
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.navLink}}
+          @props={{hash className=this.className to="/active" data-test-nav-link=""}}
+          @providerOptions={{this.reactProviderOptions}}
+        />
+      `);
+
+      assert.dom('[data-test-nav-link]').hasClass('custom-active');
+    });
   });
 });

--- a/test-app/tests/integration/components/nav-link-test.js
+++ b/test-app/tests/integration/components/nav-link-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import { setupIntl } from 'ember-intl/test-support';
 
 import { setupRenderingTest } from 'test-app/tests/helpers';
@@ -96,6 +96,24 @@ module('Integration | Component | NavLink', function (hooks) {
       `);
 
       assert.dom('[data-test-nav-link]').hasAttribute('aria-current', 'custom');
+    });
+
+    test('should set custom style', async function (assert) {
+      this.style = ({ isActive }) => ({
+        color: isActive ? 'red' : 'black',
+      });
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.navLink}}
+          @props={{hash
+          style=this.style
+          to="/active" data-test-nav-link=""}}
+          @providerOptions={{this.reactProviderOptions}}
+        />
+      `);
+
+      let elementStyle = find('[data-test-nav-link]').style;
+      assert.strictEqual(elementStyle.color, 'red');
     });
   });
 });

--- a/test-app/tests/integration/components/nav-link-test.js
+++ b/test-app/tests/integration/components/nav-link-test.js
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { render } from '@ember/test-helpers';
+import { setupIntl } from 'ember-intl/test-support';
+
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { CustomProviders } from 'test-app/react/custom-providers';
+
+import { NavLink } from '@qonto/react-migration-toolkit/react/components';
+
+module('Integration | Component | NavLink', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  hooks.beforeEach(function () {
+    this.setProperties({
+      navLink: NavLink,
+      reactProviderOptions: { component: CustomProviders },
+    });
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ReactBridge
+        @reactComponent={{this.navLink}}
+        @props={{hash to="/test" data-test-nav-link=""}}
+        @providerOptions={{this.reactProviderOptions}}
+      />
+    `);
+
+    assert.dom('[data-test-nav-link]').exists();
+  });
+});


### PR DESCRIPTION
### Description

This MR goal is to create `NavLink` component. As described by [React Router API](https://api.reactrouter.com/v7/functions/react_router.NavLink.html), it :
- Wraps [<Link>](https://api.reactrouter.com/v7/functions/react_router.Link.html) with additional props for styling active and pending states.

  - Automatically applies classes to the link based on its active and pending states, see [NavLinkProps.className](https://api.reactrouter.com/v7/interfaces/react_router.NavLinkProps.html#className).
  - Automatically applies aria-current="page" to the link when the link is active. See [aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) on MDN. 
  
As `isPending` cannot be reproduced, we focused on `active` state only.

### Reproduction instructions

Review commit by commit highly recommended. Each commit contains the related integration tests. 

### Resources
- [React Router documentation](https://reactrouter.com/start/library/navigating#navlink)
- [NavLink API Reference](https://api.reactrouter.com/v7/functions/react_router.NavLink.html)