### PR TITLE
feat: add typecheck to `useFlag` hook

### DIFF
--- a/react-migration-toolkit/src/react/contexts/launchdarkly-context.tsx
+++ b/react-migration-toolkit/src/react/contexts/launchdarkly-context.tsx
@@ -3,12 +3,21 @@ import { createContext, type ReactNode, type PropsWithChildren } from 'react';
 export type FlagValue = boolean | string;
 export type LDFlagSet = Record<string, FlagValue>;
 
-export const LDContext = createContext<LDFlagSet | null>(null);
+import { camelizeObjectKeys } from '../utils/camelize-object-keys';
 
-interface LDProviderProps extends PropsWithChildren {
-  ldFlags: LDFlagSet;
+interface LDProviderProps<Flags> extends PropsWithChildren {
+  ldFlags: Flags;
 }
 
-export function LDProvider({ children, ldFlags }: LDProviderProps): ReactNode {
-  return <LDContext.Provider value={ldFlags}>{children}</LDContext.Provider>;
+export const LDContext = createContext<LDFlagSet>({});
+
+export function LDProvider<Flags extends Record<string, FlagValue>>({
+  children,
+  ldFlags,
+}: LDProviderProps<Flags>): ReactNode {
+  return (
+    <LDContext.Provider value={camelizeObjectKeys(ldFlags)}>
+      {children}
+    </LDContext.Provider>
+  );
 }

--- a/react-migration-toolkit/src/react/contexts/launchdarkly-context.tsx
+++ b/react-migration-toolkit/src/react/contexts/launchdarkly-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, type ReactNode, type PropsWithChildren } from 'react';
 
-type FlagValue = boolean | string;
+export type FlagValue = boolean | string;
 export type LDFlagSet = Record<string, FlagValue>;
 
 export const LDContext = createContext<LDFlagSet | null>(null);

--- a/react-migration-toolkit/src/react/hooks/use-flags.ts
+++ b/react-migration-toolkit/src/react/hooks/use-flags.ts
@@ -1,30 +1,14 @@
 import { useContext } from 'react';
-import { type LDFlagSet, LDContext } from '../contexts/launchdarkly-context';
+import {
+  camelizeObjectKeys,
+  type CamelizedKeys,
+} from '../utils/camelize-object-keys';
+import { type FlagValue, LDContext } from '../contexts/launchdarkly-context';
 
-export const useFlags = (): LDFlagSet => {
+export const useFlags = (): CamelizedKeys<Record<string, FlagValue>> => {
   const allFlags = useContext(LDContext);
   if (!allFlags) {
     throw new Error('useFlags must be used within a LDProvider');
   }
-  return camelizeFlags(allFlags);
-};
-
-const camelize = (text: string): string => {
-  return text.replace(
-    /-+(?<letter>[a-z])/g,
-    (match: string, letter: string) => {
-      return letter.toUpperCase();
-    },
-  );
-};
-
-const camelizeFlags = (flags: LDFlagSet): LDFlagSet => {
-  return Object.entries(flags).reduce<LDFlagSet>(
-    (camelizedFlags, [key, value]) => {
-      const camelizedKey = camelize(key);
-      camelizedFlags[camelizedKey] = value;
-      return camelizedFlags;
-    },
-    {},
-  );
+  return camelizeObjectKeys(allFlags);
 };

--- a/react-migration-toolkit/src/react/hooks/use-flags.ts
+++ b/react-migration-toolkit/src/react/hooks/use-flags.ts
@@ -5,10 +5,10 @@ import {
 } from '../utils/camelize-object-keys';
 import { type FlagValue, LDContext } from '../contexts/launchdarkly-context';
 
-export const useFlags = (): CamelizedKeys<Record<string, FlagValue>> => {
+export const useFlags = () => {
   const allFlags = useContext(LDContext);
   if (!allFlags) {
     throw new Error('useFlags must be used within a LDProvider');
   }
-  return camelizeObjectKeys(allFlags);
+  return allFlags;
 };

--- a/react-migration-toolkit/src/react/utils/camelize-object-keys.ts
+++ b/react-migration-toolkit/src/react/utils/camelize-object-keys.ts
@@ -1,0 +1,29 @@
+// Type to transform dash-separated keys to camelCase
+type DashToCamelCase<S extends string> = S extends `${infer P1}--${infer P2}`
+  ? DashToCamelCase<`${P1}-${P2}`>
+  : S extends `${infer P1}-${infer P2}`
+  ? `${P1}${Capitalize<DashToCamelCase<P2>>}`
+  : S;
+
+// Type to transform an object's keys from dash-separated to camelCase
+export type CamelizedKeys<T> = {
+  [K in keyof T as DashToCamelCase<string & K>]: T[K];
+};
+
+function toCamelCase(str: string): string {
+  return str
+    .replace(/--/g, '-')
+    .replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+/**
+ * Transform an object's keys from dash-separated to camelCase
+ * ensuring strict type checking
+ */
+export function camelizeObjectKeys<T extends Record<string, unknown>>(
+  obj: T,
+): CamelizedKeys<T> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [toCamelCase(key), value]),
+  ) as CamelizedKeys<T>;
+}

--- a/test-app/tests/unit/utilities/camelize-object-keys-test.ts
+++ b/test-app/tests/unit/utilities/camelize-object-keys-test.ts
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { camelizeObjectKeys } from '@qonto/react-migration-toolkit/react/utils/camelize-object-keys';
+
+module('Unit | Utility | camelizeObjectKeys', function() {
+  test('should return the feature flags camelized', function(assert) {
+    const featureFlags = camelizeObjectKeys<Record<string, boolean | string>>({
+      'feature--boolean-example-flag': true,
+      'feature--string-example-flag': 'string',
+    });
+    const camelizeFeatureFlags = {
+      featureBooleanExampleFlag: true,
+      featureStringExampleFlag: 'string',
+    };
+    assert.deepEqual(featureFlags, camelizeFeatureFlags);
+  });
+});


### PR DESCRIPTION
## Context
Right now the `useFlag` hook just returns `Record<string, FlagValue>`. This PR updates the returned type using a recursive typescript type to automatically translate each pascal-case key into a camelCase one.

This is helpful for code completition and static type checks.