### PR TITLE
fix(Link): should also trigger onClick from props

### DIFF
--- a/react-migration-toolkit/src/react/components/link.tsx
+++ b/react-migration-toolkit/src/react/components/link.tsx
@@ -11,6 +11,7 @@ export interface LinkProps extends Omit<ComponentPropsWithoutRef<'a'>, 'href'> {
 
 export function Link({
   children,
+  onClick,
   replace,
   to,
   ...props
@@ -33,7 +34,8 @@ export function Link({
     return '';
   }, [to, router]);
 
-  const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+  const onClickHandler = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (onClick) onClick(event);
     event.preventDefault();
     if (replace) {
       router.replaceWith(url);
@@ -43,7 +45,7 @@ export function Link({
   };
 
   return (
-    <a href={url} onClick={onClick} {...props}>
+    <a href={url} onClick={onClickHandler} {...props}>
       {children}
     </a>
   );

--- a/test-app/tests/integration/components/link-test.js
+++ b/test-app/tests/integration/components/link-test.js
@@ -1,0 +1,58 @@
+import { module, test } from 'qunit';
+import { hbs } from 'ember-cli-htmlbars';
+import { click, render } from '@ember/test-helpers';
+import sinon from 'sinon';
+
+import { setupIntl } from 'ember-intl/test-support';
+
+import { setupRenderingTest } from 'test-app/tests/helpers';
+import { CustomProviders } from 'test-app/react/custom-providers';
+
+import { Link } from '@qonto/react-migration-toolkit/react/components';
+
+module('Integration | Component | Link', function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'en-us');
+
+  hooks.beforeEach(function () {
+    this.router = this.owner.lookup('service:router');
+    let transitionTo = {
+      promise() {
+        return 'result';
+      },
+    };
+    this.router.transitionTo = sinon.spy(transitionTo, 'promise');
+    this.setProperties({
+      link: Link,
+      reactProviderOptions: { component: CustomProviders },
+    });
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <ReactBridge
+        @reactComponent={{this.link}}
+        @props={{hash to="/links" data-test-link=""}}
+        @providerOptions={{this.reactProviderOptions}}
+      />
+    `);
+
+    assert.dom('[data-test-link]').exists();
+  });
+
+  test('should trigger onClick', async function (assert) {
+    this.onClick = sinon.fake();
+    await render(hbs`
+      <ReactBridge
+        @reactComponent={{this.link}}
+        @props={{hash onClick=this.onClick to="/links" data-test-link=""}}
+        @providerOptions={{this.reactProviderOptions}}
+      />
+    `);
+
+    await click('[data-test-link]');
+
+    assert.true(this.onClick.calledOnce);
+    assert.true(this.router.transitionTo.calledWith('/links'));
+  });
+});


### PR DESCRIPTION
### Description

This MR goal is to fix `onClick` prop from `Link` component. If passed to the component, it was overwriting our internal one which is not the expected behavior. Instead, let's align with [react router code](https://github.com/remix-run/react-router/blob/a3e4b8ed875611637357647fcf862c2bc61f4e11/packages/react-router/lib/dom/lib.tsx#L631) and trigger onClick from props inside our internal click.

### Reproduction instructions

Integration tests have been added for this component. It contains a test for this specific case which was not tested in existing acceptance tests.