### PR TITLE
feat(react-modifier) Allow children prop to be passed

### DIFF
--- a/react-migration-toolkit/src/components/react-bridge.gts
+++ b/react-migration-toolkit/src/components/react-bridge.gts
@@ -12,9 +12,7 @@ type ExtraProps = Partial<{
   [ariaAttrs: `aria-${string}`]: string;
 }>;
 
-type PropsOf<T> = T extends ComponentType<infer P>
-  ? Omit<P, 'children'> & ExtraProps
-  : never;
+type PropsOf<T> = T extends ComponentType<infer P> ? P & ExtraProps : never;
 
 interface ReactBridgeArgs<T extends keyof HTMLElementTagNameMap, R> {
   Element: ElementFromTagName<T>;

--- a/react-migration-toolkit/src/modifiers/react-modifier.ts
+++ b/react-migration-toolkit/src/modifiers/react-modifier.ts
@@ -54,7 +54,7 @@ export default class ReactModifier extends Modifier<ReactModifierSignature> {
 
   modify(
     element: Element,
-    positional: null,
+    _: null,
     { reactComponent, props, providerOptions, hasBlock }: ReactModifierOptions,
   ) {
     if (!this.root) {

--- a/test-app/app/components/example.hbs
+++ b/test-app/app/components/example.hbs
@@ -12,3 +12,13 @@
   @props={{hash text=this.safeText data-test-example="true"}}
   class="class-from-bridge"
 />
+
+<ReactBridge
+  @reactComponent={{this.reactExample}}
+  @props={{hash children=this.reactExample}}
+/>
+
+<ReactBridge
+  @reactComponent={{this.reactExample}}
+  @props={{hash children="Children as Props"}}
+/>

--- a/test-app/app/react/example.tsx
+++ b/test-app/app/react/example.tsx
@@ -20,6 +20,7 @@ export function Example({ text, children, ...props }: ExampleProps): ReactNode {
     <div
       data-test-has-owner={owner instanceof ApplicationInstance}
       data-test-theme={theme?.current}
+      style={{ border: "1px solid gray", padding: 16, margin: 16 }}
       {...props}
     >
       <h1>Hi there 👋</h1>
@@ -45,7 +46,7 @@ export function Example({ text, children, ...props }: ExampleProps): ReactNode {
         <div data-test-children>
           <hr />
           <h3>Children values:</h3>
-          {children}
+          <div data-test-children-content>{children}</div>
         </div>
       )}
     </div>

--- a/test-app/tests/integration/components/react-bridge-test.js
+++ b/test-app/tests/integration/components/react-bridge-test.js
@@ -272,4 +272,41 @@ module('Integration | Component | react-bridge', function (hooks) {
       .hasAttribute('href', 'https://www.google.com')
       .hasText('world');
   });
+
+  module('when children prop is passed directly', function () {
+    test('it correctly renders strings', async function (assert) {
+      let text = `Test text as children`;
+
+      this.setProperties({
+        reactExample: Example,
+        props: {
+          children: text,
+        },
+      });
+
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.reactExample}}
+          @props={{hash children=this.props.children}}
+        />
+    `);
+
+      assert.dom('[data-test-children-content]').hasText(text);
+    });
+
+    test('it correctly renders ReactNode', async function (assert) {
+      this.setProperties({
+        reactExample: Example,
+      });
+
+      await render(hbs`
+        <ReactBridge
+          @reactComponent={{this.reactExample}}
+          @props={{hash children=this.reactExample}}
+        />
+    `);
+
+      assert.dom('h1').exists({ count: 2 });
+    });
+  });
 });


### PR DESCRIPTION
### Description

Right now, passing children to the component does not work, the only children allowed was the one passed within ember while leveraging `yield` and `block` features.

This MR allows to pass a direct `children` prop from the `ReactBridge` component which will take preference over the block one.

```hbs
  <ReactBridge
          @reactComponent={{this.reactExample}}
          @props={{hash children="Works string"}}
        />
 ```
 
 It does also allow to pass ReactNodes:
 
 ```hbs
  <ReactBridge
          @reactComponent={{this.reactExample}}
          @props={{hash children=this.reactExample}}
        />
 ```