### PR TITLE
chore(PolymorphicNavigateContext): export Path type

### DIFF
--- a/react-migration-toolkit/src/react/contexts/polymorphic-navigate-context.tsx
+++ b/react-migration-toolkit/src/react/contexts/polymorphic-navigate-context.tsx
@@ -8,7 +8,7 @@ export interface PolymorphicNavigate {
   ): void | Promise<void> | Promise<boolean>;
 }
 
-interface Path
+export interface Path
   extends Partial<{
     hash: string;
     pathname: string;


### PR DESCRIPTION
This PR goal is to export Path type from polymorphic-navigate-context.