### PR TITLE
[Fix] Prevent access on destroyed owner

### DIFF
--- a/react-migration-toolkit/src/react/contexts/application-context.tsx
+++ b/react-migration-toolkit/src/react/contexts/application-context.tsx
@@ -1,4 +1,17 @@
-import { createContext, type ReactNode, type PropsWithChildren } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  type PropsWithChildren,
+  useState,
+  useEffect,
+} from 'react';
+import {
+  createContext,
+  type ReactNode,
+  type PropsWithChildren,
+  useState,
+  useEffect,
+} from 'react';
 import type ApplicationInstance from '@ember/application/instance';
 
 interface ApplicationProviderProps extends PropsWithChildren {
@@ -13,6 +26,20 @@ export function ApplicationProvider({
   owner,
   children,
 }: ApplicationProviderProps): ReactNode {
+  const [isDestroyed, setIsDestroyed] = useState<boolean>(false);
+
+  useEffect(() => {
+    const oldWillDestroy = owner.willDestroy;
+    owner.willDestroy = (...args) => {
+      setIsDestroyed(true);
+      oldWillDestroy.apply(owner, args);
+    };
+  }, [owner]);
+
+  if (isDestroyed) {
+    return null;
+  }
+
   return (
     <ApplicationContext.Provider value={owner}>
       {children}


### PR DESCRIPTION
We've got some cases when Ember App is destroyed, but React component still tries to access an Ember service. This results in an error:

```
Error: Cannot call `.lookup('service:organization-manager')` after the owner has been destroyed
    at Container.lookup (http://localhost:7357/assets/vendor.js:575:15)
    at ApplicationInstance.lookup (http://localhost:7357/assets/vendor.js:10272:33)
    at useEmberService (http://localhost:7357/assets/chunk.b17651e957f6f92a7c28.js:6328:16)
    at useOrganizationManager (http://localhost:7357/assets/chunk.20e8505b24b143d532a8.js:6423:101)
    at useFetchForwardingEmail (http://localhost:7357/assets/chunk.20edc446a6268cec6b84.js:14706:105)
    at CopyEmailButton (http://localhost:7357/assets/chunk.20edc446a6268cec6b84.js:333:125)
    at renderWithHooks (http://localhost:7357/assets/chunk.b17651e957f6f92a7c28.js:97930:157)
    at updateFunctionComponent (http://localhost:7357/assets/chunk.b17651e957f6f92a7c28.js:98502:388)
    at beginWork (http://localhost:7357/assets/chunk.b17651e957f6f92a7c28.js:98910:549)
    at beginWork$1 (http://localhost:7357/assets/chunk.b17651e957f6f92a7c28.js:99966:93)
```

To prevent that, we should remove all Application Context children once the owner is destroyed.